### PR TITLE
add: タイトルとTwitterカードを追加

### DIFF
--- a/mo-code/index.html
+++ b/mo-code/index.html
@@ -1,12 +1,18 @@
 <!DOCTYPE html>
 <html>
   <head>
+    <meta charset="utf-8">
+    <meta name="twitter:card" content="summary"/>
+    <meta name="twitter:site" content="@happy_packet"/>
+    <meta property="og:url" content="https://iranika.github.io/mo-code/index.html"/>
+    <meta property="og:title" content="みちくさびゅあー"/>
+    <meta property="og:description" content="桃鳥様公認のばっくやーど4コマビュアーです。"/>
     <link rel="stylesheet" href="./w3.css">
     <link rel="stylesheet" href="./style.css">
     <link rel="stylesheet" href="./modal.css">
-    <meta charset="utf-8">
     <script src="./4komaData.js"></script>
     <script src="./viewer.js"></script>
+    <title>みちくさびゅあー</title>
   </head>
   <body id="body">
     <div class="modal">


### PR DESCRIPTION
いままで無かったタイトルを追加。
Twitterにリンクを張ったときにリッチに見えるようにTwitterカードを試験的に追加。
Twitterカードのサムネ画像がいいのが決まらないので一旦スルー。