### PR TITLE
Fix: テキストの文言を修正

### DIFF
--- a/mo-code/index.html
+++ b/mo-code/index.html
@@ -6,7 +6,7 @@
   <meta name="twitter:site" content="@happy_packet" />
   <meta property="og:url" content="https://iranika.github.io/mo-code/index.html" />
   <meta property="og:title" content="みちくさびゅあー" />
-  <meta property="og:description" content="桃鳥様公認のばっくやーど4コマビュアーです。" />
+  <meta property="og:description" content="桃鳥様公認の道草屋漫画ビューアーです。" />
   <link rel="icon" href="./img/favicon.ico" type="image/x-icon" />
   <link rel="icon" href="./img/favicon.png" sizes="48x48">
   <link rel="stylesheet" href="./css/w3.css">

--- a/mo-code/js/michikusa-viewer.js
+++ b/mo-code/js/michikusa-viewer.js
@@ -12,7 +12,7 @@ const viewer = (()=>{
       isAutoShowMore : true,
       tweetText: encodeURI("ここすき\n#みちくさびゅあー"),
       tweetHashTag: encodeURI(""),
-      tweetUrl: encodeURI("http://yurika.iranika.info/mo-code/")
+      tweetUrl: encodeURI("http://iranika.github.io/mo-code/")
     },
     pageData : pageData,
     page : { //pageに関する変数
@@ -80,7 +80,8 @@ const viewer = (()=>{
       viewer.pageData[pageNum].ImagesUrl.forEach(img_url => {
         viewer.elem.view.innerHTML += `<img class="hidden-image" src="${img_url}">`
       })
-      viewer.elem.view.innerHTML += `<a class="tweetbtn hidden-image" href="https://twitter.com/intent/tweet?original_referer=https%3A%2F%2Fpublish.twitter.com%2F%3FbuttonText%3D%25E3%2581%2593%25E3%2581%2593%25E3%2581%2599%25E3%2581%258D%25EF%25BC%2581%25EF%25BC%2581%2523%25E3%2581%25BF%25E3%2581%25A1%25E3%2581%258F%25E3%2581%2595%25E3%2581%25B3%25E3%2582%2585%25E3%2581%2582%25E3%2583%25BC%26buttonType%3DTweetButton%26buttonUrl%3Dhttps%253A%252F%252Fyurika.iranika.info%252Fmo-code%252F%252310%26dnt%3D1%26lang%3Dja%26widget%3DButton&ref_src=twsrc%5Etfw&text=%E3%81%93%E3%81%93%E3%81%99%E3%81%8D%EF%BC%81%EF%BC%81%23%E3%81%BF%E3%81%A1%E3%81%8F%E3%81%95%E3%81%B3%E3%82%85%E3%81%82%E3%83%BC&tw_p=tweetbutton&url=https%3A%2F%2Firanika.github.io%2Fmo-code%2F%23${pageNum +1}"><span class="label">ツイートする</span></a>`
+      let tw_text = encodeURI(`第${pageNum +1}話「${viewer.pageData[pageNum].Title}」`)
+      viewer.elem.view.innerHTML += `<a class="tweetbtn hidden-image" href="https://twitter.com/intent/tweet?hashtags=%E9%81%93%E8%8D%89%E5%B1%8B&original_referer=https%3A%2F%2Fpublish.twitter.com%2F%3FbuttonText%3D%25E3%2581%2593%25E3%2581%2593%25E3%2581%2599%25E3%2581%258D%25EF%25BC%2581%25EF%25BC%2581%2523%25E3%2581%25BF%25E3%2581%25A1%25E3%2581%258F%25E3%2581%2595%25E3%2581%25B3%25E3%2582%2585%25E3%2581%2582%25E3%2583%25BC%26buttonType%3DTweetButton%26buttonUrl%3Dhttps%253A%252F%252Firanika.github.io%252Fmo-code%252F%252310%26dnt%3D1%26lang%3Dja%26widget%3DButton&ref_src=twsrc%5Etfw&text=${tw_text}&tw_p=tweetbutton&url=https%3A%2F%2Firanika.github.io%2Fmo-code%2F%23${pageNum +1}"><span class="label">ツイートする</span></a>`
     }
   }
 })();


### PR DESCRIPTION
- ばっくやーど数コマを道草屋漫画と呼称することに統一
- ツイートの文言を話数とタイトルに変更
